### PR TITLE
CODEOWNERS: Make PullAssigner the default owner

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 # Add the list of code owners here (using their GitHub username)
+* gatekeeper-PullAssigner


### PR DESCRIPTION
The PullAssigner bot [1] will pick 2 github handles from the gate
keepers list [2] and assign them for reviewing any new PR.
The bot goes uses a round robin algorithm to select handles from the
list.

What happens when the CODEOWNERS file gets populated with real
owners? Following the PR review and approval process [3], the
PullAssigner bot will either pick only one or zero reviewers from the
gate keepers list, if the CODEOWNERS file points to exactly one or more
than one actual ownwer, respectively.

[1] https://pullpanda.com/assigner
[2] https://github.com/rust-vmm/community/blob/master/GATEKEEPERS.md
[3] https://github.com/rust-vmm/community#pr-review-and-approval

Signed-off-by: Samuel Ortiz <sameo@linux.intel.com>
